### PR TITLE
Improve Node Display

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
@@ -153,3 +153,43 @@ export const Cards: Story = {
     );
   },
 };
+
+export const CardNodeWithLongAwsName: Story = {
+  render() {
+    const longAwsNameNode = makeUnifiedResourceViewItemNode(
+      {
+        kind: 'node',
+        id: 'n-long-card',
+        hostname: 'aops-dev-i-0a29549ea62aeae08',
+        labels: [
+          { name: 'cluster', value: 'one' },
+          { name: 'aws/Name', value: 'aops-dev-i-0a29549ea62aeae08' },
+        ],
+        addr: '172.10.1.20:3022',
+        tunnel: false,
+        subKind: 'teleport',
+        requiresRequest: false,
+      },
+      { ActionButton }
+    );
+
+    return (
+      <MemoryRouter>
+        <SamlAppActionProvider>
+          <Grid gap={2}>
+            <ResourceCard
+              pinned={false}
+              pinResource={() => {}}
+              selectResource={() => {}}
+              selected={false}
+              pinningSupport={PinningSupport.Supported}
+              onShowStatusInfo={() => null}
+              showingStatusInfo={false}
+              viewItem={longAwsNameNode}
+            />
+          </Grid>
+        </SamlAppActionProvider>
+      </MemoryRouter>
+    );
+  },
+};

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
@@ -163,7 +163,7 @@ export const CardNodeWithLongAwsName: Story = {
         hostname: 'aops-dev-i-0a29549ea62aeae08',
         labels: [
           { name: 'cluster', value: 'one' },
-          { name: 'aws/Name', value: 'aops-dev-i-0a29549ea62aeae08' },
+          { name: 'aws/Name', value: 'aops-dev-i-0a29549ea62aeae08-super-long' },
         ],
         addr: '172.10.1.20:3022',
         tunnel: false,

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -541,4 +541,5 @@ const SuffixPill = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  margin-right: ${p => p.theme.space[2]}px;
 `;

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -232,11 +232,22 @@ export function ResourceCard({
           {/* MinWidth is important to prevent descriptions from overflowing. */}
           <Flex flexDirection="column" flex="1" minWidth="0" ml={3} gap={1}>
             <Flex flexDirection="row" alignItems="center">
-              <SingleLineBox flex="1">
-                <HoverTooltip tipContent={name} showOnlyOnOverflow>
-                  <Text typography="body1">{name}</Text>
-                </HoverTooltip>
-              </SingleLineBox>
+              <Flex flex="1" minWidth="0" alignItems="center" gap={2}>
+                <SingleLineBox flex="none" maxWidth="100%">
+                  <HoverTooltip tipContent={name} showOnlyOnOverflow>
+                    <Text typography="body1">{name}</Text>
+                  </HoverTooltip>
+                </SingleLineBox>
+                {cardViewProps.titleSuffix && (
+                  <HoverTooltip tipContent={cardViewProps.titleSuffix} showOnlyOnOverflow>
+                    <SuffixPill>
+                      <Text typography="body3" color="text.slightlyMuted">
+                        {cardViewProps.titleSuffix}
+                      </Text>
+                    </SuffixPill>
+                  </HoverTooltip>
+                )}
+              </Flex>
               {hovered && <CopyButton name={name} mr={2} />}
               <ResourceActionButtonWrapper requiresRequest={requiresRequest}>
                 {ActionButton}
@@ -519,4 +530,15 @@ const MoreLabelsButton = styled(ButtonLink)`
   &:hover {
     background-color: transparent;
   }
+`;
+
+const SuffixPill = styled.div`
+  border-radius: ${p => p.theme.radii[2]}px;
+  background-color: ${p => p.theme.colors.levels.sunken};
+  border: ${p => p.theme.borders[1]} ${p => p.theme.colors.spotBackground[0]};
+  padding: 0 ${p => p.theme.space[2]}px;
+  max-width: 50%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -234,10 +234,10 @@ export function ResourceCard({
             <Flex flexDirection="row" alignItems="center">
               <Flex flex="1" minWidth="0" alignItems="center" gap={2}>
                 <SingleLineBox flex="none" maxWidth="100%">
-                  <HoverTooltip tipContent={name} showOnlyOnOverflow>
-                    <Text typography="body1">{name}</Text>
-                  </HoverTooltip>
-                </SingleLineBox>
+                <HoverTooltip tipContent={name} showOnlyOnOverflow>
+                  <Text typography="body1">{name}</Text>
+                </HoverTooltip>
+              </SingleLineBox>
                 {cardViewProps.titleSuffix && (
                   <HoverTooltip tipContent={cardViewProps.titleSuffix} showOnlyOnOverflow>
                     <SuffixPill>

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
@@ -133,3 +133,41 @@ export const ListItems: Story = {
     );
   },
 };
+
+export const NodeWithLongAwsName: Story = {
+  render() {
+    const longAwsNameNode = makeUnifiedResourceViewItemNode(
+      {
+        kind: 'node',
+        id: 'n-long',
+        hostname: 'aops-dev-i-0a29549ea62aeae08',
+        labels: [
+          { name: 'cluster', value: 'one' },
+          { name: 'aws/Name', value: 'devops1.aopstest.com' },
+        ],
+        addr: '172.10.1.20:3022',
+        tunnel: false,
+        subKind: 'teleport',
+        requiresRequest: false,
+      },
+      { ActionButton }
+    );
+
+    return (
+      <Flex flexDirection="column">
+        <ResourceListItem
+          pinned={false}
+          pinResource={() => {}}
+          selectResource={() => {}}
+          selected={false}
+          pinningSupport={PinningSupport.Supported}
+          expandAllLabels={false}
+          onLabelClick={() => {}}
+          onShowStatusInfo={() => null}
+          showingStatusInfo={false}
+          viewItem={longAwsNameNode}
+        />
+      </Flex>
+    );
+  },
+};

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
@@ -143,7 +143,7 @@ export const NodeWithLongAwsName: Story = {
         hostname: 'aops-dev-i-0a29549ea62aeae08',
         labels: [
           { name: 'cluster', value: 'one' },
-          { name: 'aws/Name', value: 'devops1.aopstest.com' },
+          { name: 'aws/Name', value: 'aops-dev-i-0a29549ea62aeae08-super-super-long-name' },
         ],
         addr: '172.10.1.20:3022',
         tunnel: false,

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -167,10 +167,10 @@ export function ResourceListItem({
                 alignItems="center"
                 css={`
                   min-width: 0;
-                  overflow: hidden;
-                `}
-              >
-                <HoverTooltip tipContent={name} showOnlyOnOverflow>
+              overflow: hidden;
+            `}
+          >
+            <HoverTooltip tipContent={name} showOnlyOnOverflow>
                   <Name
                     css={`
                       min-width: 0;
@@ -190,7 +190,7 @@ export function ResourceListItem({
                       {titleSuffix}
                     </Text>
                   </ListSuffixPill>
-                </HoverTooltip>
+            </HoverTooltip>
               )}
             </Flex>
             {/* Second row: description */}

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -61,7 +61,7 @@ export function ResourceListItem({
     requiresRequest = false,
     status,
   } = viewItem;
-  const { description, resourceType, addr } = listViewProps;
+  const { description, resourceType, addr, titleSuffix } = listViewProps;
 
   const [showLabels, setShowLabels] = useState(expandAllLabels);
   const [hovered, setHovered] = useState(false);
@@ -151,22 +151,53 @@ export function ResourceListItem({
             flexDirection="column"
             css={`
               overflow: hidden;
+              width: 100%;
             `}
           >
-            <HoverTooltip tipContent={name} showOnlyOnOverflow>
-              <Name>{name}</Name>
-            </HoverTooltip>
+            {/* Top row: name + copy button, and AWS name pill on the same row */}
+            <Flex
+              alignItems="center"
+              css={`
+                overflow: hidden;
+                width: 100%;
+                gap: ${props => props.theme.space[2]}px;
+              `}
+            >
+              <Flex
+                alignItems="center"
+                css={`
+                  min-width: 0;
+                  overflow: hidden;
+                `}
+              >
+                <HoverTooltip tipContent={name} showOnlyOnOverflow>
+                  <Name
+                    css={`
+                      min-width: 0;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                    `}
+                  >
+                    {name}
+                  </Name>
+                </HoverTooltip>
+                {hovered && <CopyButton name={name} ml={1} />}
+              </Flex>
+              {titleSuffix && (
+                <HoverTooltip tipContent={titleSuffix} showOnlyOnOverflow>
+                  <ListSuffixPill>
+                    <Text fontSize="12px" color="text.slightlyMuted">
+                      {titleSuffix}
+                    </Text>
+                  </ListSuffixPill>
+                </HoverTooltip>
+              )}
+            </Flex>
+            {/* Second row: description */}
             <HoverTooltip tipContent={description} showOnlyOnOverflow>
               <Description>{description}</Description>
             </HoverTooltip>
           </Flex>
-          <Box
-            css={`
-              align-self: start;
-            `}
-          >
-            {hovered && <CopyButton name={name} ml={1} />}
-          </Box>
         </Flex>
 
         {/* type */}
@@ -383,6 +414,19 @@ const Name = styled(Text)`
   white-space: nowrap;
   line-height: 20px;
   font-weight: 300;
+`;
+
+const ListSuffixPill = styled.div`
+  border-radius: ${p => p.theme.radii[2]}px;
+  background-color: ${p => p.theme.colors.levels.sunken};
+  border: ${p => p.theme.borders[1]} ${p => p.theme.colors.spotBackground[0]};
+  padding: 0 ${p => p.theme.space[2]}px;
+  max-width: 50%;
+  align-self: center;
+  margin-left: ${p => p.theme.space[2]}px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const Description = styled(Text)`

--- a/web/packages/shared/components/UnifiedResources/shared/viewItemsFactory.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/viewItemsFactory.ts
@@ -50,6 +50,12 @@ export function makeUnifiedResourceViewItemNode(
   const nodeSubKind = formatNodeSubKind(resource.subKind);
   const addressIfNotTunnel = resource.tunnel ? '' : resource.addr;
 
+  // If present, surface the AWS Name label value on the card without requiring label expansion.
+  const awsNameLabel = resource.labels.find(l => l.name === 'aws/Name');
+  const awsName = (awsNameLabel?.value || '').trim();
+  // Keep secondary description as address only to avoid duplicating the AWS name.
+  const secondaryDescCombined = addressIfNotTunnel;
+
   return {
     name: resource.hostname,
     SecondaryIcon: ServerIcon,
@@ -58,11 +64,13 @@ export function makeUnifiedResourceViewItemNode(
     labels: resource.labels,
     cardViewProps: {
       primaryDesc: nodeSubKind,
-      secondaryDesc: addressIfNotTunnel,
+      secondaryDesc: secondaryDescCombined,
+      titleSuffix: awsName,
     },
     listViewProps: {
       resourceType: nodeSubKind,
       addr: addressIfNotTunnel,
+      titleSuffix: awsName,
     },
     requiresRequest: resource.requiresRequest,
   };

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -226,12 +226,16 @@ export type ResourceItemProps = {
 type CardViewSpecificProps = {
   primaryDesc?: string;
   secondaryDesc?: string;
+  /** Optional short text to render inline next to the title (eg: AWS Name). */
+  titleSuffix?: string;
 };
 
 type ListViewSpecificProps = {
   description?: string;
   addr?: string;
   resourceType: string;
+  /** Optional short text to render inline next to the title (eg: AWS Name). */
+  titleSuffix?: string;
 };
 
 export type UnifiedResourcesPinning =

--- a/web/packages/teleport/src/Nodes/fixtures/index.ts
+++ b/web/packages/teleport/src/Nodes/fixtures/index.ts
@@ -37,6 +37,10 @@ export const nodes: Node[] = [
         name: 'kernel',
         value: '4.15.0-51-generic',
       },
+      {
+        name: 'aws/Name',
+        value: 'MyEC2Server',
+      },
     ],
   },
   {


### PR DESCRIPTION
### Summary
Surface the AWS Name for SSH nodes directly in Resources, visible without expanding labels.

### Changes
- Added `titleSuffix` support to Unified Resources view models:
  - `web/packages/shared/components/UnifiedResources/types.ts`
    - CardViewSpecificProps: add `titleSuffix?: string`
    - ListViewSpecificProps: add `titleSuffix?: string`
- Node view item mapping:
  - `web/packages/shared/components/UnifiedResources/shared/viewItemsFactory.ts`
    - For `kind: 'node'`, extract `aws/Name` label value
    - Set `cardViewProps.titleSuffix` and `listViewProps.titleSuffix` to that value
    - Keep `cardViewProps.secondaryDesc` as address only (avoid duplication)
- Card view UI:
  - `web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx`
    - Render `titleSuffix` as a small pill next to the hostname (inline, truncates, tooltip)
- List view UI:
  - `web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx`
    - Restructured name area into two rows:
      - Top row: name + copy button, plus AWS Name pill on the same line
      - Bottom row: description
    - Ensures proper ellipsis/overflow, stable layout
- Storybook fixture:
  - `web/packages/teleport/src/Nodes/fixtures/index.ts`
    - Added `aws/Name: "MyEC2Server"` to the first node so the change is visible in stories

### Behavior
- SSH nodes now show the AWS Name inline next to the hostname in both card and list views (no click required).
- Tooltips show full values; long names gracefully truncate.
- Secondary line remains for address, unchanged for other kinds.

### Verification
- Storybook: “Shared/UnifiedResources” stories reflect the change; the first node shows an AWS Name inline.
- No behavior change for non-node resources.